### PR TITLE
Remove docker/charts from Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2
 
 go-image: &go-image quay.io/deis/lightweight-docker-go:v0.2.0
 docker-image: &docker-image docker:18.03.0-dind
-chart-image: &chart-image quay.io/deis/helm-chart-publishing-tools:v0.1.1
 redis-image: &redis-image redis:3.2.4
 
 base-go-job: &base-go-job
@@ -21,10 +20,6 @@ install-make-and-git-step: &install-make-and-git-step
   command: |
     apk update
     apk add make git
-log-into-docker-hub-step: &log-into-docker-hub-step
-  name: Log into Docker Hub
-  command: docker login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}"
-
 jobs:
   lint:
     <<: *base-go-job
@@ -52,17 +47,6 @@ jobs:
       - run:
           name: Lint Go Code
           command: make lint
-  lint-chart:
-    docker:
-      - image: *chart-image
-    environment:
-      SKIP_DOCKER: true
-    working_directory: /go/src/github.com/Azure/open-service-broker-azure
-    steps:
-      - checkout
-      - run:
-          name: Run Lint Helm Chart
-          command: make lint-chart
   verify-vendored-code:
     <<: *base-go-job
     steps:
@@ -151,56 +135,6 @@ jobs:
       - run:
           name: Run Service Lifecycle Tests
           command: make test-service-lifecycles
-  publish-rc-images:
-    <<: *base-docker-job
-    environment:
-      DOCKER_REPO: microsoft/
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          <<: *install-make-and-git-step
-      - run:
-          <<: *log-into-docker-hub-step
-      - run:
-          name: Publish Release Candidate Images to Docker Hub
-          command: make push-rc
-  publish-release-images:
-    <<: *base-docker-job
-    environment:
-      DOCKER_REPO: microsoft/
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          <<: *install-make-and-git-step
-      - run:
-          <<: *log-into-docker-hub-step
-      - run:
-          name: Publish Release Images to Docker Hub
-          command: REL_VERSION="${CIRCLE_TAG}" make push-release
-  publish-rc-chart:
-    docker:
-      - image: *chart-image
-    environment:
-      SKIP_DOCKER: true
-    working_directory: /go/src/github.com/Azure/open-service-broker-azure
-    steps:
-      - checkout
-      - run:
-          name: Publish Helm Chart
-          command: make publish-rc-chart
-  publish-release-chart:
-    docker:
-      - image: *chart-image
-    environment:
-      SKIP_DOCKER: true
-    working_directory: /go/src/github.com/Azure/open-service-broker-azure
-    steps:
-      - checkout
-      - run:
-          name: Publish Helm Chart
-          command: REL_VERSION="${CIRCLE_TAG}" make publish-release-chart
 
 base-pr-step: &base-pr-step
   filters:
@@ -230,10 +164,6 @@ workflows:
           <<: *base-pr-step
           requires:
             - hold
-      - lint-chart:
-          <<: *base-pr-step
-          requires:
-            - hold
       - verify-vendored-code:
           <<: *base-pr-step
           requires:
@@ -259,7 +189,6 @@ workflows:
           requires:
             - hold
             - lint
-            - lint-chart
             - verify-vendored-code
             - test-unit
             - test-api-compliance
@@ -269,8 +198,6 @@ workflows:
     jobs:
       - lint:
           <<: *base-master-step
-      - lint-chart:
-          <<: *base-master-step
       - verify-vendored-code:
           <<: *base-master-step
       - test-unit:
@@ -285,42 +212,12 @@ workflows:
           <<: *base-master-step
           requires:
             - lint
-            - lint-chart
             - verify-vendored-code
             - test-unit
             - test-api-compliance
             - build
             - test-generate-pcf-tile
-      - publish-rc-images:
-          <<: *base-master-step
-          requires:
-            - lint
-            - lint-chart
-            - verify-vendored-code
-            - test-unit
-            - test-api-compliance
-            - build
-            - test-generate-pcf-tile
-            - test-service-lifecycles
-      - publish-rc-chart:
-          <<: *base-master-step
-          requires:
-            - lint
-            - lint-chart
-            - verify-vendored-code
-            - test-unit
-            - test-api-compliance
-            - build
-            - test-generate-pcf-tile
-            - test-service-lifecycles
-            - publish-rc-images
   release:
     jobs:
       - generate-pcf-tile:
           <<: *base-release-step
-      - publish-release-images:
-          <<: *base-release-step
-      - publish-release-chart:
-          <<: *base-release-step
-          requires:
-            - publish-release-images

--- a/pkg/services/mssql/dbms_registered_provision.go
+++ b/pkg/services/mssql/dbms_registered_provision.go
@@ -55,7 +55,7 @@ func (d *dbmsRegisteredManager) getServer(
 			"sql server version validation failed, "+
 				"expected version: %s, actual version: %s",
 			expectedVersion,
-			result.Version,
+			*result.Version,
 		)
 	}
 	expectedLocation := strings.Replace(


### PR DESCRIPTION
As advanced OSBA now targets on advanced CF customers / PCF tile, we don't provide docker releases and helm charts. For the future, it depends.